### PR TITLE
reduced buffer sizes so APS beamline PLCs would work

### DIFF
--- a/ether_ipApp/src/ether_ip.h
+++ b/ether_ipApp/src/ether_ip.h
@@ -174,7 +174,7 @@ void EIP_hexdump(int level, const void *_data, int len);
 extern int EIP_buffer_limit;
 
 /** Best estimate for EIP_buffer_limit */
-#define EIP_DEFAULT_BUFFER_LIMIT 500
+#define EIP_DEFAULT_BUFFER_LIMIT 480
 
 /** Used to be used to determine EIP_DEFAULT_BUFFER_LIMIT, but
  *  didn't work out
@@ -185,7 +185,7 @@ extern int EIP_buffer_limit;
  *  buffer size that the driver uses to allocate the initial
  *  buffer.
  */
-#define EIP_BUFFER_SIZE 600
+#define EIP_BUFFER_SIZE 580
 
 /********************************************************
  * ControlNet data types


### PR DESCRIPTION
At the Advanced Photon Source, the BCDA group had not been able to use more recent versions of ether_ip for a couple of years (since the buffer size calculation was changed). After finding from our Interlocks group that the buffer size in the PLCs they have been using had gone down a little and caused them problems, I was able to fix the problem by reducing the buffer sizes by 20 bytes. 