### PR TITLE
Make -Wno-unused-value compiler flag Darwin-only

### DIFF
--- a/ether_ipApp/src/Makefile
+++ b/ether_ipApp/src/Makefile
@@ -6,7 +6,7 @@ include $(TOP)/configure/CONFIG
 #  ADD MACRO DEFINITIONS AFTER THIS LINE
 
 # On Darwin, got errors about unused assignment in recGblSetSevr
-USR_CFLAGS += -Wno-unused-value
+USR_CFLAGS_Darwin += -Wno-unused-value
 
 # On WIN32, have to add socket library
 # to build the test program


### PR DESCRIPTION
When compiling version 2-27 and HEAD with the VxWorks 5.5 Tornado 2.2 toolchain, the compile fails due to the `-Wno-unused-value` option:

```
  cc1: Invalid option `-Wno-unused-value'
```

Since the comment for the addition of the flag to `USR_CFLAGS` indicates it was to address an issue on `Darwin`, restrict the addition of the flag to `Darwin` which then allows the `vxWorks` compile of version 2-27 to succeed (and the compile of HEAD to advance further even though it will hit other problems such as the K&R-style variable declarations requirement).